### PR TITLE
Fix AmazonSES exception namespace

### DIFF
--- a/app/Utils/AmazonSES.php
+++ b/app/Utils/AmazonSES.php
@@ -23,7 +23,7 @@ class AmazonSES {
 
   public function __construct() {
     if (!isset($_ENV['SES_ACCESS_KEY']) || !isset($_ENV['SES_SECRET_ACCESS_KEY'])) {
-      throw new Exception('SES_ACCESS_KEY and SES_SECRET_ACCESS_KEY must be set in .env file'); 
+      throw new \Exception('SES_ACCESS_KEY and SES_SECRET_ACCESS_KEY must be set in .env file');
     }
 
     $this->key = $_ENV['SES_ACCESS_KEY'];


### PR DESCRIPTION
## Summary
- ensure AmazonSES throws global Exception when AWS keys are missing

## Testing
- `php -l app/Utils/AmazonSES.php` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ac929b688332b3259b7a043491dc